### PR TITLE
Fixes for tempRange switching to avoid max / min values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ build/
 
 # Added by Homey CLI
 /.homeybuild/
+package-lock.json
 
 # VScode
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,11 @@ typings/
 
 build/
 
-
 # Added by Homey CLI
 /.homeybuild/
+
+# VScode
+.vscode/
+
+# snyk
+.dccache

--- a/drivers/main-device.js
+++ b/drivers/main-device.js
@@ -323,7 +323,7 @@ module.exports = class mainDevice extends Homey.Device {
         this.homey.app.log(`[Device] ${this.getName()} - setValue => ${key} => `, value);
 
         if (this.hasCapability(key)) {
-            const newKey = key.replace('.', '_');
+            const newKey = key.replace(/\./g, '_');
             const oldVal = await this.getCapabilityValue(key);
             const newVal = roundNumber ? Math.round(value) : value
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -38,7 +38,7 @@ toCelsius = function (value) {
 };
 
 toFahrenheit = function (value) {
-    return roundHalf(parseFloat(value) * (9/5) + 32);
+    return parseFloat(value) * (9/5) + 32;
 };
 
 roundHalf = function (num) {


### PR DESCRIPTION
I don't think it is the best solution, but seems to work.
Removed also rounding from toFahrenheit.
Not sure if you want to keep the key.replace change. It is unlikely, that there would be more than one "." in capability names.