### PR TITLE
Remove rounding from toFahrenheit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,7 @@ build/
 
 # Added by Homey CLI
 /.homeybuild/
+/package-lock.json
+
+# Snyk cash
+.dccache

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -38,7 +38,7 @@ toCelsius = function (value) {
 };
 
 toFahrenheit = function (value) {
-    return roundHalf(parseFloat(value) * (9/5) + 32);
+    return parseFloat(value) * (9/5) + 32;
 };
 
 roundHalf = function (num) {


### PR DESCRIPTION
Needs to be exact value.
One strange but consisuten behaviour from the CMS App is, that it always send
value + 0.4 to the API. Didn't chhange this, yet.