### PR TITLE
NEW: device settings to synchronize the spa clock with Homey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ build/
 
 # Added by Homey CLI
 /.homeybuild/
+/package-lock.json
+
+.dccache

--- a/.homeycompose/drivers/templates/settings.json
+++ b/.homeycompose/drivers/templates/settings.json
@@ -81,23 +81,17 @@
           "value": true
         },
         {
-          "id": "clock_sync_interval",
-          "type": "number",
+          "id": "clock_sync",
+          "type": "checkbox",
           "label": {
-            "en": "Synchronize every (hours)",
-            "nl": "Synchroniseer elke (uur)"
+            "en": "Synchronize spa clock",
+            "nl": "Synchroniseer spa klok"
           },
           "hint": {
-            "en": "The clock will be synchronized at the next update interval. Set to 0 to disable. Every 24 hours is recommended.",
-            "nl": "De klok zal gesynchroniseerd worden bij de volgende update interval. Zet op 0 om uit te schakelen. Elke 24 uur wordt aangeraden."
+            "en": "If enabled, the spa clock will be synchronized with Homey's local time when needed.",
+            "nl": "Indien ingeschakeld, zal de spa klok gesynchroniseerd worden met de lokale tijd van Homey wanneer nodig."
           },
-          "min": 0,
-          "max": 24,
-          "units": {
-            "en": "hours",
-            "nl": "uur"
-          },
-          "value": 0
+          "value": false
         }
       ]
     }

--- a/.homeycompose/drivers/templates/settings.json
+++ b/.homeycompose/drivers/templates/settings.json
@@ -59,6 +59,48 @@
           "value": ""
         }
       ]
+    },
+    {
+      "type": "group",
+      "label": {
+        "en": "Spa clock settings",
+        "nl": "Spa klok instellingen"
+      },
+      "children": [
+        {
+          "id": "clock_sync",
+          "type": "checkbox",
+          "label": {
+            "en": "Synchronize with Homey",
+            "nl": "Synchroniseren met Homey"
+          },
+          "value": true
+        },
+        {
+          "id": "clock_24",
+          "type": "checkbox",
+          "label": {
+            "en": "Set 24h clock",
+            "nl": "24-uurs klok"
+          },
+          "value": true
+        },
+        {
+          "id": "clock_sync_interval",
+          "type": "number",
+          "label": {
+            "en": "Synchronize every (hours)",
+            "nl": "Synchroniseer elke (uur)"
+          },
+          "min": 1,
+          "max": 24,
+          "units": {
+            "en": "hours",
+            "nl": "uur"
+          },
+          "value": 1
+        }
+      ]
     }
   ]
 }

--- a/.homeycompose/drivers/templates/settings.json
+++ b/.homeycompose/drivers/templates/settings.json
@@ -68,20 +68,15 @@
       },
       "children": [
         {
-          "id": "clock_sync",
-          "type": "checkbox",
-          "label": {
-            "en": "Synchronize with Homey",
-            "nl": "Synchroniseren met Homey"
-          },
-          "value": true
-        },
-        {
           "id": "clock_24",
           "type": "checkbox",
           "label": {
-            "en": "Set 24h clock",
+            "en": "24h clock",
             "nl": "24-uurs klok"
+          },
+          "hint":{
+            "en": "If enabled, the spa clock will be set to 24h format, otherwise 12h format.",
+            "nl": "Indien ingeschakeld, zal de spa klok ingesteld worden op 24-uurs formaat, anders 12-uurs formaat."
           },
           "value": true
         },
@@ -92,13 +87,17 @@
             "en": "Synchronize every (hours)",
             "nl": "Synchroniseer elke (uur)"
           },
-          "min": 1,
+          "hint": {
+            "en": "The clock will be synchronized at the next update interval. Set to 0 to disable. Every 24 hours is recommended.",
+            "nl": "De klok zal gesynchroniseerd worden bij de volgende update interval. Zet op 0 om uit te schakelen. Elke 24 uur wordt aangeraden."
+          },
+          "min": 0,
           "max": 24,
           "units": {
             "en": "hours",
             "nl": "uur"
           },
-          "value": 1
+          "value": 0
         }
       ]
     }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-## Control your Balboa Spa with this app.
+# Control your Balboa Spa with this app
 
-**Current features:**
+## Current features
+
 - Get spa status
 - Set temperature
 - Toggle heater mode
 - Lock/unlock panel
 - Control Jets, Blowers and Lights
+- Synchronize the spa clock with Homey

--- a/README.txt
+++ b/README.txt
@@ -6,3 +6,4 @@ Current features:
 - Toggle heater mode
 - Lock/unlock panel
 - Control Jets, Blowers and Lights
+- Synchronize the spa clock with Homey

--- a/app.json
+++ b/app.json
@@ -995,23 +995,17 @@
               "value": true
             },
             {
-              "id": "clock_sync_interval",
-              "type": "number",
+              "id": "clock_sync",
+              "type": "checkbox",
               "label": {
-                "en": "Synchronize every (hours)",
-                "nl": "Synchroniseer elke (uur)"
+                "en": "Synchronize spa clock",
+                "nl": "Synchroniseer spa klok"
               },
               "hint": {
-                "en": "The clock will be synchronized at the next update interval. Set to 0 to disable. Every 24 hours is recommended.",
-                "nl": "De klok zal gesynchroniseerd worden bij de volgende update interval. Zet op 0 om uit te schakelen. Elke 24 uur wordt aangeraden."
+                "en": "If enabled, the spa clock will be synchronized with Homey's local time when needed.",
+                "nl": "Indien ingeschakeld, zal de spa klok gesynchroniseerd worden met de lokale tijd van Homey wanneer nodig."
               },
-              "min": 0,
-              "max": 24,
-              "units": {
-                "en": "hours",
-                "nl": "uur"
-              },
-              "value": 0
+              "value": false
             }
           ]
         }

--- a/app.json
+++ b/app.json
@@ -973,6 +973,48 @@
               "value": ""
             }
           ]
+        },
+        {
+          "type": "group",
+          "label": {
+            "en": "Spa clock settings",
+            "nl": "Spa klok instellingen"
+          },
+          "children": [
+            {
+              "id": "clock_sync",
+              "type": "checkbox",
+              "label": {
+                "en": "Synchronize with Homey",
+                "nl": "Synchroniseren met Homey"
+              },
+              "value": true
+            },
+            {
+              "id": "clock_24",
+              "type": "checkbox",
+              "label": {
+                "en": "Set 24h clock",
+                "nl": "24-uurs klok"
+              },
+              "value": true
+            },
+            {
+              "id": "clock_sync_interval",
+              "type": "number",
+              "label": {
+                "en": "Synchronize every (hours)",
+                "nl": "Synchroniseer elke (uur)"
+              },
+              "min": 1,
+              "max": 24,
+              "units": {
+                "en": "hours",
+                "nl": "uur"
+              },
+              "value": 1
+            }
+          ]
         }
       ],
       "name": {

--- a/app.json
+++ b/app.json
@@ -982,20 +982,15 @@
           },
           "children": [
             {
-              "id": "clock_sync",
-              "type": "checkbox",
-              "label": {
-                "en": "Synchronize with Homey",
-                "nl": "Synchroniseren met Homey"
-              },
-              "value": true
-            },
-            {
               "id": "clock_24",
               "type": "checkbox",
               "label": {
-                "en": "Set 24h clock",
+                "en": "24h clock",
                 "nl": "24-uurs klok"
+              },
+              "hint": {
+                "en": "If enabled, the spa clock will be set to 24h format, otherwise 12h format.",
+                "nl": "Indien ingeschakeld, zal de spa klok ingesteld worden op 24-uurs formaat, anders 12-uurs formaat."
               },
               "value": true
             },
@@ -1006,13 +1001,17 @@
                 "en": "Synchronize every (hours)",
                 "nl": "Synchroniseer elke (uur)"
               },
-              "min": 1,
+              "hint": {
+                "en": "The clock will be synchronized at the next update interval. Set to 0 to disable. Every 24 hours is recommended.",
+                "nl": "De klok zal gesynchroniseerd worden bij de volgende update interval. Zet op 0 om uit te schakelen. Elke 24 uur wordt aangeraden."
+              },
+              "min": 0,
               "max": 24,
               "units": {
                 "en": "hours",
                 "nl": "uur"
               },
-              "value": 1
+              "value": 0
             }
           ]
         }

--- a/drivers/main-device.js
+++ b/drivers/main-device.js
@@ -307,6 +307,7 @@ module.exports = class mainDevice extends Homey.Device {
             }
 
             // Set Spa clock if deviceInfo.timeNotSet or spa clock's hour or minute is off from Homey clock by more the 5 minutes.
+            // Also set when clock_24 setting is changed and clock_sync is enabled.
             const timeNow = new Date();
             const myTZ = this.homey.clock.getTimezone();
             const myTime = timeNow.toLocaleString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: myTZ });
@@ -314,8 +315,7 @@ module.exports = class mainDevice extends Homey.Device {
             const myTimeMinutes = Number(myTime.split(':')[0]) * 60 + Number(myTime.split(':')[1]);
             const spaTimeMinutes = (hour * 60) + minute;
 
-            if((settings.clock_sync && timeNotSet ) || (settings.clock_sync && (Math.abs(spaTimeMinutes - myTimeMinutes) > 5))) {
-                this.homey.app.log(`[Device] ${this.getName()} - Spa clock clock_24=${military} is off more than 5 minutes ${spaTimeMinutes} - ${myTimeMinutes}.`);
+            if ((settings.clock_sync && timeNotSet) || (settings.clock_sync && military !== settings.clock_24) || (settings.clock_sync && (Math.abs(spaTimeMinutes - myTimeMinutes) > 5))) {
                 this.homey.app.log(`[Device] ${this.getName()} - setClock ${myDate} ${myTime} ${myTZ} clock_24=${settings.clock_24}`);
                 await this._controlMySpaClient.setTime(myDate, myTime, settings.clock_24);
             } else {

--- a/lib/balboa/index.js
+++ b/lib/balboa/index.js
@@ -90,7 +90,7 @@ class ControlMySpa {
             if (req.status === 200) {
                 const body = req.data;
                 this.tokenData = body;
-                console.log('login succes');
+                console.log('login success');
             } else {
                 // error getting idm
                 console.error('failed to login');
@@ -149,6 +149,39 @@ class ControlMySpa {
             }
 
             return false;
+        } catch (error) {
+            console.log(error);
+        }
+    }
+
+    async setTime(date, time, military_format = true) {
+        try {
+            const timeData = {
+                date: date,
+                time: time,
+                military_format: military_format ? 'TRUE' : 'FALSE'
+            };
+
+            const req = await this.instance.post('https://iot.controlmyspa.com/mobile/control/' + this.currentSpa._id + '/setTime', timeData, {
+                headers: {
+                    Accept: 'application/json',
+                    'User-Agent': 'ControlMySpa/3.0.2 (com.controlmyspa.qa; build:1; iOS 14.2.0) Alamofire/5.2.2',
+                    'Accept-Encoding': 'br;q=1.0, gzip;q=0.9, deflate;q=0.8',
+                    'Accept-Language': 'cs-CZ;q=1.0',
+                    'Content-Length': JSON.stringify(timeData).length,
+                    'Content-Type': 'application/json',
+                    Authorization: 'Bearer ' + this.tokenData.access_token
+                }
+            });
+
+            if (req.status === 202) {
+                const body = req.data;
+            } else {
+                // error getting idm
+                console.error('failed to set time');
+            }
+
+            return req.status === 200;
         } catch (error) {
             console.log(error);
         }
@@ -228,7 +261,7 @@ class ControlMySpa {
                 return true;
             } else {
                 // error getting idm
-                console.error('failed to set temp');
+                console.error('failed to set temp range');
             }
 
             return false;

--- a/lib/balboa/index.js
+++ b/lib/balboa/index.js
@@ -154,10 +154,18 @@ class ControlMySpa {
         }
     }
 
+    /**
+     * @description Call the CMS API to set time and 24h clock format
+     * 
+     * @param {String} date in mm/dd/yyyy format
+     * @param {String} time in HH:mm format
+     * @param {Boolean} military_format true for 24h, false for 12h clock
+     */
     async setTime(date, time, military_format = true) {
+        // Escape slashes in date before sending to api
         try {
             const timeData = {
-                date: date,
+                date: date.replace(/\//g, '\\/'),
                 time: time,
                 military_format: military_format ? 'TRUE' : 'FALSE'
             };


### PR DESCRIPTION
- new balboa api setTime()
- new device interval onClockSyncInterval
- new device method setClock to call the api
- configured in device settings
- no flow cards, no capabilites

Dutch is auto-translated - need verification in settings.json
